### PR TITLE
fix: 修复自动添加后缀的函数自身调用错误

### DIFF
--- a/scripts/helper/css_auto_version.js
+++ b/scripts/helper/css_auto_version.js
@@ -5,7 +5,7 @@ function cssAutoVersionHelper(...args) {
         if (i) result += '\n';
 
         if (Array.isArray(path)) {
-            return result + Reflect.apply(cssHelper, this, path);
+            return result + Reflect.apply(cssAutoVersionHelper, this, path);
         }
         if (!path.includes('?') && !path.endsWith('.css')) path += '.css';
         let url_suffix = "?v=" + new Date().getTime();

--- a/scripts/helper/js_auto_version.js
+++ b/scripts/helper/js_auto_version.js
@@ -5,7 +5,7 @@ function jsAutoVersionHelper(...args) {
         if (i) result += '\n';
 
         if (Array.isArray(path)) {
-            return result + Reflect.apply(jsHelper, this, path);
+            return result + Reflect.apply(jsAutoVersionHelper, this, path);
         }
         if (!path.includes('?') && !path.endsWith('.js')) path += '.js';
         let url_suffix = "?v=" + new Date().getTime();


### PR DESCRIPTION
影响css_auto_version和js_auto_version，当传入参数为数组时会发生错误