### PR TITLE
style: delete the title of the hitokoto widget

### DIFF
--- a/layout/_widget/hitokoto.ejs
+++ b/layout/_widget/hitokoto.ejs
@@ -1,9 +1,6 @@
 <!-- 一言 -->
 <% if (theme.widgets.includes('hitokoto')){ %>
   <div class="nexmoe-widget-wrap">
-    <h3 class="nexmoe-widget-title">
-      <%= __('hitokoto') %>
-    </h3>
     <div class="nexmoe-widget">
       <ul class="hitokoto-box">
         <li id="hitokoto_text_parent" class="hitokoto-text" hitokotoCategory="<%= theme.widgetHitokoto.category %>">


### PR DESCRIPTION
做的事情很简单，就是将一言组件中的标题（一言）给删除了。
<img width="186" alt="image" src="https://user-images.githubusercontent.com/74645100/169656593-a4e40cc0-0c27-4784-9f8b-dad774e6e5c6.png">
