### PR TITLE
feat: add plain layout

### DIFF
--- a/layout/plain.ejs
+++ b/layout/plain.ejs
@@ -1,0 +1,24 @@
+<div class="nexmoe-post">
+
+    <article>
+        <% if (page.cover){ %>
+            <div class="nexmoe-post-cover" style="padding-bottom: <%- page.coverHeight/page.coverWidth*100 %>%;"> 
+                <img src="<%- page.cover %>" alt="<%= page.title %>" loading="lazy">
+                <h1><%= page.title %></h1>
+            </div>
+        <%}  else{ %>
+            <div class="nexmoe-post-cover" style="padding-bottom: <%- theme.background.height/theme.background.width*100 %>%;"> 
+                <img data-fancybox="gallery" src="<%- theme.background.path %>" alt="<%= page.title %>" loading="lazy">
+                <h1><%= page.title %></h1>
+            </div>
+        <% } %>
+        
+        <%- page.content %>
+    </article>
+  
+    <% if (page.comments){ %>
+        <div class="nexmoe-post-footer">
+            <%- theme.slotComment %>
+        </div>
+    <% } %>
+  </div>


### PR DESCRIPTION
# 添加一个 “plain” 布局。

## 布局特点：
该布局仅保留封面和评论框组件，相比于 post 布局，删去了标签、发布时间、字数统计等组件。

## 布局用途：
- 用于适配一些不需要多余组件的页面。比如**关于页面**就完全不需要分类、标签、发布时间、字数统计等功能。
- 另外很多插件所生成的额外页面也不需要额外的组件。

下面是一组**关于页面**的使用效果对比：
使用前：
<img width="697" alt="image" src="https://user-images.githubusercontent.com/74645100/184115025-8107af05-af49-48b4-9c1c-b2b3e7d66539.png">

使用后：
<img width="695" alt="image" src="https://user-images.githubusercontent.com/74645100/184114925-1a632801-c033-4cc8-8f8a-29b4485c4153.png">

下面是一组 [hexo-bilibili-bangumi](https://github.com/HCLonely/hexo-bilibili-bangumi)的使用效果对比：
使用前：
<img width="694" alt="image" src="https://user-images.githubusercontent.com/74645100/184115529-af4fd4a1-c48d-48d8-b050-229b90af5775.png">

使用后：
<img width="695" alt="image" src="https://user-images.githubusercontent.com/74645100/184115291-7e21f154-66ce-47aa-9608-b3efeb05d8a3.png">

