### PR TITLE
fix: 搜索结果英文不换行

### DIFF
--- a/source/css/_partial/searchbox.styl
+++ b/source/css/_partial/searchbox.styl
@@ -74,6 +74,7 @@
                         padding-left: 17px;
                         bottom: 10px;
                         margin-top: 10px;
+                        word-wrap: break-word;
                     }
 
                     .keyword {


### PR DESCRIPTION
在使用 `local（本地搜索）时`，英文会超出父级元素，

![image](https://user-images.githubusercontent.com/31686695/194989337-7ddf71cb-bc7a-45ff-bff5-922b629c8f79.png)

使用 `word-wrap: break-word; `实现换行

![image](https://user-images.githubusercontent.com/31686695/194989312-4e832d33-5899-4093-9884-1d093ac2fbc6.png)
