### PR TITLE
fix: 侧边栏消失问题

### DIFF
--- a/source/lib/mdui_043tiny/mdui.js
+++ b/source/lib/mdui_043tiny/mdui.js
@@ -5003,6 +5003,9 @@
           // 没有强制关闭，则状态为打开状态
           if (!_this.$drawer.hasClass('mdui-drawer-close')) {
             _this.state = 'opened';
+          } else {
+            // 宽屏下应显示侧边栏
+            _this.$drawer.removeClass('mdui-drawer-close');
           }
         }
 
@@ -5211,9 +5214,9 @@
       _this.state = 'opening';
       componentEvent('open', 'drawer', _this, _this.$drawer);
 
-      if (!_this.options.overlay) {
-        $('body').addClass('mdui-drawer-body-' + _this.position);
-      }
+      // if (!_this.options.overlay) {
+      //   $('body').addClass('mdui-drawer-body-' + _this.position);
+      // }
 
       _this.$drawer
         .removeClass('mdui-drawer-close')
@@ -5245,9 +5248,9 @@
       _this.state = 'closing';
       componentEvent('close', 'drawer', _this, _this.$drawer);
 
-      if (!_this.options.overlay) {
-        $('body').removeClass('mdui-drawer-body-' + _this.position);
-      }
+      // if (!_this.options.overlay) {
+      //   $('body').removeClass('mdui-drawer-body-' + _this.position);
+      // }
 
       _this.$drawer
         .addClass('mdui-drawer-close')


### PR DESCRIPTION
大佬您好，发现 nexmoe 侧边栏响应式存在一个问题。

复现方法：
1. 宽屏下进入页面
2. resize 窗口至页面呈现移动端布局
3. 开启左侧菜单栏
4. 点击遮罩层关闭菜单栏
5. 恢复宽屏
6. 这时宽屏下不会再显示侧边栏

我没有找到相关的 issue ，不确定这算不算是 feature ，但是我感觉这种表现好像不太符合我的预期，所以先提了一个 PR 。如果不存在问题的话您完全可以关闭它，抱歉打扰您了。