### PR TITLE
fix: 修复window.onload事件相互覆盖的问题

### DIFF
--- a/layout/_widget/hitokoto.ejs
+++ b/layout/_widget/hitokoto.ejs
@@ -21,7 +21,7 @@
   let hitokotoText = document.getElementById('hitokoto_text')
   let hitokotoErroText = document.getElementById('hitokoto_error_text')
   let hitokotoCategory = document.getElementById('hitokoto_text_parent').getAttribute('hitokotoCategory')
-  window.onload = function () {
+  window.addEventListener('load', function () {
     let url = 'https://v1.hitokoto.cn'
     if (hitokotoCategory) {
       url += '?c=' + hitokotoCategory
@@ -37,5 +37,5 @@
         hitokotoText.style.display = 'none'
         hitokotoErroText.style.display = 'block'
       })
-  }
+  });
 </script>

--- a/layout/_widget/hitokoto.ejs
+++ b/layout/_widget/hitokoto.ejs
@@ -37,5 +37,5 @@
         hitokotoText.style.display = 'none'
         hitokotoErroText.style.display = 'block'
       })
-  });
+  })
 </script>

--- a/source/js/copy-codeblock.js
+++ b/source/js/copy-codeblock.js
@@ -1,4 +1,4 @@
-window.onload = () => {
+window.addEventListener('load', () => {
   const codeBlocks = document.querySelectorAll('figure.highlight');
   if (!codeBlocks.length) return;
 
@@ -47,4 +47,4 @@ window.onload = () => {
   };
 
   codeBlocks.forEach(addCopyButton);
-};
+});


### PR DESCRIPTION
抱歉，开发时疏忽了，一言的 `window.onload` 跟代码块复制的互相覆盖掉了，我把两个地方的 API 改成了 `addEventListener`