### PR TITLE
chore: accelerate lint speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ node_modules
 WIKI/.vuepress/dist
 
 .vscode/
+
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"license": "Apache-2.0",
 	"main": "index.js",
 	"scripts": {
-		"lint": "eslint --ext .js --ext .jsx --ext .json ."
+		"lint": "eslint --cache --ext .js --ext .jsx --ext .json ."
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
I found there is a `lint` script in `package.json`, you can add `--cache` to cache the lint info for next lint operations.

BTW, Why don't you have `.eslintrc` configuration files in your repo...